### PR TITLE
Update apis to not have conflicting names

### DIFF
--- a/example/macros/json.dart
+++ b/example/macros/json.dart
@@ -5,14 +5,14 @@ const jsonSerializable = _JsonMacro();
 class _JsonMacro implements ClassDeclarationMacro, ClassDefinitionMacro {
   const _JsonMacro();
 
-  void declare(TargetClassDeclaration declaration) {
+  void forClassDeclaration(TargetClassDeclaration declaration) {
     declaration
       ..addToClass(Code('external Map<String, Object?> toJson();'))
       ..addToClass(Code(
           'external ${declaration.name}.fromJson(Map<String, Object?> json);'));
   }
 
-  void define(TargetClassDefinition definition) {
+  void forClassDefinition(TargetClassDefinition definition) {
     _defineFromJson(definition);
     _defineToJson(definition);
   }

--- a/example/macros/observable.dart
+++ b/example/macros/observable.dart
@@ -2,26 +2,32 @@ import 'package:macro_builder/macro_builder.dart';
 
 const observable = ObservableMacro();
 
-class ObservableMacro implements FieldDeclarationMacro {
+class ObservableMacro implements FieldDeclarationMacro, ClassDeclarationMacro {
   const ObservableMacro();
 
-  void declare(TargetFieldDeclaration definition) {
-    if (!definition.name.startsWith('_')) {
+  void forClassDeclaration(TargetClassDeclaration declaration) {
+    for (var field in declaration.fields) {
+      forFieldDeclaration(field);
+    }
+  }
+
+  void forFieldDeclaration(TargetFieldDeclaration declaration) {
+    if (!declaration.name.startsWith('_')) {
       throw ArgumentError(
           '@observable can only annotate private fields, and it will create '
           'public getters and setters for them, but the public field '
-          '${definition.name} was annotated.');
+          '${declaration.name} was annotated.');
     }
-    var publicName = definition.name.substring(1);
-    var getter = Code('${definition.type.toCode()} get $publicName => '
-        '${definition.name};');
-    definition.addToClass(getter);
+    var publicName = declaration.name.substring(1);
+    var getter = Code('${declaration.type.toCode()} get $publicName => '
+        '${declaration.name};');
+    declaration.addToClass(getter);
 
     var setter = Code('''
-void set $publicName(${definition.type.toCode()} val) {
+void set $publicName(${declaration.type.toCode()} val) {
   print('Setting $publicName to \${val}');
-  ${definition.name} = val;
+  ${declaration.name} = val;
 }''');
-    definition.addToClass(setter);
+    declaration.addToClass(setter);
   }
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -19,6 +19,11 @@ void main() {
   var manager2 = Manager.fromJson(manager.toJson());
   assert(jsonEncode(manager2.toJson()) == jsonEncode(manager.toJson()));
 
-  var observable = new ObservableThing('hello');
+  var observable = WithObservableField('hello');
   observable.description = 'world';
+
+  var observableClass = ObservableClass('jake', 'is pretty cool');
+  observableClass
+    ..name = 'john'
+    ..description = 'is also cool';
 }

--- a/example/observable.dart
+++ b/example/observable.dart
@@ -1,12 +1,30 @@
 import 'macros/observable.dart';
 
-class ObservableThing {
+class WithObservableField {
   @observable
   String _description;
-  ObservableThing(this._description);
+  WithObservableField(this._description);
   String get description => _description;
   void set description(String val) {
     print('Setting description to ${val}');
     _description = val;
+  }
+}
+
+@observable
+class ObservableClass {
+  String _description;
+  String _name;
+  ObservableClass(this._name, this._description);
+  String get description => _description;
+  void set description(String val) {
+    print('Setting description to ${val}');
+    _description = val;
+  }
+
+  String get name => _name;
+  void set name(String val) {
+    print('Setting name to ${val}');
+    _name = val;
   }
 }

--- a/example/observable.declarations.dart
+++ b/example/observable.declarations.dart
@@ -1,6 +1,6 @@
 import 'macros/observable.dart';
 
-class ObservableThing {
+class WithObservableField {
   @observable
   String _description;
   String get description => _description;
@@ -9,5 +9,24 @@ class ObservableThing {
     _description = val;
   }
 
-  ObservableThing(this._description);
+  WithObservableField(this._description);
+}
+
+@observable
+class ObservableClass {
+  String get description => _description;
+  void set description(String val) {
+    print('Setting description to ${val}');
+    _description = val;
+  }
+
+  String get name => _name;
+  void set name(String val) {
+    print('Setting name to ${val}');
+    _name = val;
+  }
+
+  String _description;
+  String _name;
+  ObservableClass(this._name, this._description);
 }

--- a/example/observable.gen.dart
+++ b/example/observable.gen.dart
@@ -1,8 +1,16 @@
 import 'macros/observable.dart';
 
-class ObservableThing {
+class WithObservableField {
   @observable
   String _description;
 
-  ObservableThing(this._description);
+  WithObservableField(this._description);
+}
+
+@observable
+class ObservableClass {
+  String _description;
+  String _name;
+
+  ObservableClass(this._name, this._description);
 }

--- a/example/observable.types.dart
+++ b/example/observable.types.dart
@@ -1,7 +1,14 @@
 import 'macros/observable.dart';
 
-class ObservableThing {
+class WithObservableField {
   @observable
   String _description;
-  ObservableThing(this._description);
+  WithObservableField(this._description);
+}
+
+@observable
+class ObservableClass {
+  String _description;
+  String _name;
+  ObservableClass(this._name, this._description);
 }

--- a/lib/macro_builder.dart
+++ b/lib/macro_builder.dart
@@ -160,7 +160,7 @@ class TypesMacroBuilder extends _MacroBuilder {
         throw ArgumentError(
             'Macro $macro can only be used on classes, but was found on $element');
       }
-      macro.type(_ImplementableTargetClassType(element, libraryBuffer));
+      macro.forClassType(_ImplementableTargetClassType(element, libraryBuffer));
     }
   }
 }
@@ -178,27 +178,31 @@ class DeclarationsMacroBuilder extends _MacroBuilder {
       StringBuffer buffer,
       StringBuffer libraryBuffer) async {
     if (!checker.hasAnnotationOf(element)) return null;
-    if (macro is ClassDeclarationMacro) {
-      if (element is! ClassElement) {
+    if (element is ClassElement) {
+      if (macro is! ClassDeclarationMacro) {
         throw ArgumentError(
-            'Macro $macro can only be used on classes, but was found on $element');
+            'Macro $macro was found on $element but isn\'t intended to be used '
+            ' on that type of declaration.');
       }
-      macro.declare(_ImplementableTargetClassDeclaration(element,
+      macro.forClassDeclaration(_ImplementableTargetClassDeclaration(element,
           classBuffer: buffer, libraryBuffer: libraryBuffer));
       // TODO: return list of names of declarations modified
-    }
-    if (macro is FieldDeclarationMacro) {
-      if (element is! FieldElement) {
+    } else if (element is FieldElement) {
+      if (macro is! FieldDeclarationMacro) {
         throw ArgumentError(
-            'Macro $macro can only be used on fields, but was found on $element');
+            'Macro $macro was found on $element but isn\'t intended to be used '
+            ' on that type of declaration.');
       }
-      macro.declare(_ImplementableTargetFieldDeclaration(element, buffer));
-    } else if (macro is MethodDeclarationMacro) {
-      if (element is! MethodElement) {
+      macro.forFieldDeclaration(
+          _ImplementableTargetFieldDeclaration(element, buffer));
+    } else if (element is MethodElement) {
+      if (macro is! MethodDeclarationMacro) {
         throw ArgumentError(
-            'Macro $macro can only be used on methods, but was found on $element');
+            'Macro $macro was found on $element but isn\'t intended to be used '
+            ' on that type of declaration.');
       }
-      macro.declare(_ImplementableTargetMethodDeclaration(element, buffer));
+      macro.forMethodDeclaration(
+          _ImplementableTargetMethodDeclaration(element, buffer));
     }
   }
 }
@@ -222,7 +226,7 @@ class DefinitionsMacroBuilder extends _MacroBuilder {
             'Macro $macro can only be used on classes, but was found on $element');
       }
       var targetClass = _ImplementableTargetClassDefinition(element, buffer);
-      macro.define(targetClass);
+      macro.forClassDefinition(targetClass);
       return targetClass._implementedDeclarations;
     } else if (macro is FieldDefinitionMacro) {
       if (element is! FieldElement) {
@@ -230,7 +234,8 @@ class DefinitionsMacroBuilder extends _MacroBuilder {
             'Macro $macro can only be used on fields, but was found on $element');
       }
       var fieldBuffer = StringBuffer();
-      macro.define(_ImplementableTargetFieldDefinition(element, buffer));
+      macro.forFieldDefinition(
+          _ImplementableTargetFieldDefinition(element, buffer));
       if (fieldBuffer.isNotEmpty) {
         var node = (await resolver.astNodeFor(element, resolve: true))!
             .parent!
@@ -246,7 +251,8 @@ class DefinitionsMacroBuilder extends _MacroBuilder {
             'Macro $macro can only be used on methods, but was found on $element');
       }
       var methodBuffer = StringBuffer();
-      macro.define(_ImplementableTargetMethodDefinition(element, methodBuffer));
+      macro.forMethodDefinition(
+          _ImplementableTargetMethodDefinition(element, methodBuffer));
       if (methodBuffer.isNotEmpty) {
         var node = (await resolver.astNodeFor(element, resolve: true))
             as ast.MethodDeclaration;

--- a/lib/src/macro.dart
+++ b/lib/src/macro.dart
@@ -11,37 +11,37 @@ abstract class DeclarationMacro implements Macro {}
 abstract class DefinitionMacro implements Macro {}
 
 abstract class ClassTypeMacro implements TypeMacro {
-  void type(TargetClassType type);
+  void forClassType(TargetClassType type);
 }
 
 abstract class ClassDeclarationMacro implements DeclarationMacro {
-  void declare(TargetClassDeclaration declaration);
+  void forClassDeclaration(TargetClassDeclaration declaration);
 }
 
 abstract class ClassDefinitionMacro implements DefinitionMacro {
-  void define(TargetClassDefinition definition);
+  void forClassDefinition(TargetClassDefinition definition);
 }
 
 abstract class FieldTypeMacro implements TypeMacro {
-  void type(TargetFieldType type);
+  void forFieldType(TargetFieldType type);
 }
 
 abstract class FieldDeclarationMacro implements DeclarationMacro {
-  void declare(TargetFieldDeclaration declaration);
+  void forFieldDeclaration(TargetFieldDeclaration declaration);
 }
 
 abstract class FieldDefinitionMacro implements DefinitionMacro {
-  void define(TargetFieldDefinition definition);
+  void forFieldDefinition(TargetFieldDefinition definition);
 }
 
 abstract class MethodTypeMacro implements TypeMacro {
-  void type(TargetMethodType type);
+  void forMethodType(TargetMethodType type);
 }
 
 abstract class MethodDeclarationMacro implements DeclarationMacro {
-  void declare(TargetMethodDeclaration declaration);
+  void forMethodDeclaration(TargetMethodDeclaration declaration);
 }
 
 abstract class MethodDefinitionMacro implements DefinitionMacro {
-  void define(TargetMethodDefinition definition);
+  void forMethodDefinition(TargetMethodDefinition definition);
 }


### PR DESCRIPTION
This allows a macro to implement multiple types of macros. I updated the observable example as a use case, it can now annotate a whole class (making all fields observable), or just individual fields.

@munificent PTAL and give some feedback on the names... probably just the first commit is all you really need to look at.