### PR TITLE
Move the mutation API out to separate builder objects.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,5 @@
+import: "package:pedantic/analysis_options.yaml"
+
 analyzer:
   strong-mode:
     implicit-casts: false
@@ -5,3 +7,4 @@ analyzer:
 linter:
   rules:
     - unawaited_futures
+    - unnecessary_overrides

--- a/example/macros/data_class.dart
+++ b/example/macros/data_class.dart
@@ -6,8 +6,9 @@ const dataClass = const _DataClass();
 class _DataClass implements ClassDeclarationMacro {
   const _DataClass();
 
-  void declare(TargetClassDeclaration declaration) {
-    autoConstructor.declare(declaration);
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) {
+    autoConstructor.visitClassDeclaration(declaration, builder);
   }
 }
 
@@ -16,7 +17,8 @@ const autoConstructor = const _AutoConstructor();
 class _AutoConstructor implements ClassDeclarationMacro {
   const _AutoConstructor();
 
-  void declare(TargetClassDeclaration declaration) {
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) {
     if (declaration.constructors.any((c) => c.name == '')) {
       throw ArgumentError(
           'Cannot generate a constructor because one already exists');
@@ -28,7 +30,7 @@ class _AutoConstructor implements ClassDeclarationMacro {
     }
     var superclass = declaration.superclass;
     MethodDeclaration? superconstructor;
-    if (superclass != null) {
+    if (superclass is ClassDeclaration) {
       var superconstructor =
           superclass.constructors.firstWhereOrNull((c) => c.name == '');
       if (superconstructor == null) {
@@ -65,7 +67,7 @@ class _AutoConstructor implements ClassDeclarationMacro {
       code = Code('$code)');
     }
     code = Code('$code;');
-    declaration.addToClass(code);
+    builder.addToClass(code);
   }
 }
 
@@ -74,7 +76,8 @@ const copyWith = const _CopyWith();
 class _CopyWith implements ClassDeclarationMacro {
   const _CopyWith();
 
-  void declare(TargetClassDeclaration declaration) {
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) {
     if (declaration.methods.any((c) => c.name == 'copyWith')) {
       throw ArgumentError(
           'Cannot generate a copyWith method because one already exists');

--- a/example/macros/observable.dart
+++ b/example/macros/observable.dart
@@ -5,7 +5,8 @@ const observable = ObservableMacro();
 class ObservableMacro implements FieldDeclarationMacro {
   const ObservableMacro();
 
-  void declare(TargetFieldDeclaration definition) {
+  void visitFieldDeclaration(
+      FieldDeclaration definition, ClassDeclarationBuilder builder) {
     if (!definition.name.startsWith('_')) {
       throw ArgumentError(
           '@observable can only annotate private fields, and it will create '
@@ -15,13 +16,13 @@ class ObservableMacro implements FieldDeclarationMacro {
     var publicName = definition.name.substring(1);
     var getter = Code('${definition.type.toCode()} get $publicName => '
         '${definition.name};');
-    definition.addToClass(getter);
+    builder.addToClass(getter);
 
     var setter = Code('''
 void set $publicName(${definition.type.toCode()} val) {
   print('Setting $publicName to \${val}');
   ${definition.name} = val;
 }''');
-    definition.addToClass(setter);
+    builder.addToClass(setter);
   }
 }

--- a/example/user.dart
+++ b/example/user.dart
@@ -4,48 +4,54 @@ import 'macros/json.dart';
 @dataClass
 @jsonSerializable
 class User {
-  User.fromJson(
-    Map<String, Object?> json,
-  ) : name = json["name"] as String;
+  String name;
+  @jsonSerializable
   Map<String, Object?> toJson() => <String, Object?>{
         "name": name,
       };
-  String name;
+
+  @jsonSerializable
+  User.fromJson(
+    Map<String, Object?> json,
+  ) : name = json["name"] as String;
+
   User({required this.name});
 }
 
 @dataClass
 @jsonSerializable
 class Group {
+  final String name;
+  final List<User> users;
+  @jsonSerializable
+  Map<String, Object?> toJson() => <String, Object?>{
+        "name": name,
+        "users": [for (var e in users) e],
+      };
+
+  @jsonSerializable
   Group.fromJson(
     Map<String, Object?> json,
   )   : name = json["name"] as String,
-        users = [
-          for (var e in json["users"] as List<Object?>)
-            User.fromJson(e as Map<String, Object?>)
-        ];
-  Map<String, Object?> toJson() => <String, Object?>{
-        "name": name,
-        "users": [for (var e in users) e.toJson()],
-      };
-  final String name;
-  final List<User> users;
+        users = [for (var e in json["users"] as List<Object?>) e as User];
+
   Group({required this.name, required this.users});
 }
 
 @jsonSerializable
 class Manager extends User {
-  Manager.fromJson(
-    Map<String, Object?> json,
-  )   : reports = [
-          for (var e in json["reports"] as List<Object?>)
-            User.fromJson(e as Map<String, Object?>)
-        ],
-        super.fromJson(json);
+  final List<User> reports;
+  @jsonSerializable
   Map<String, Object?> toJson() => <String, Object?>{
-        "reports": [for (var e in reports) e.toJson()],
+        "reports": [for (var e in reports) e],
         "name": name,
       };
-  final List<User> reports;
+
+  @jsonSerializable
+  Manager.fromJson(
+    Map<String, Object?> json,
+  )   : reports = [for (var e in json["reports"] as List<Object?>) e as User],
+        super.fromJson(json);
+
   Manager({required String name, required this.reports}) : super(name: name);
 }

--- a/example/user.declarations.dart
+++ b/example/user.declarations.dart
@@ -4,7 +4,9 @@ import 'macros/json.dart';
 @dataClass
 @jsonSerializable
 class User {
+  @jsonSerializable
   external Map<String, Object?> toJson();
+  @jsonSerializable
   external User.fromJson(Map<String, Object?> json);
   User({
     required this.name,
@@ -15,7 +17,9 @@ class User {
 @dataClass
 @jsonSerializable
 class Group {
+  @jsonSerializable
   external Map<String, Object?> toJson();
+  @jsonSerializable
   external Group.fromJson(Map<String, Object?> json);
   Group({
     required this.name,
@@ -27,7 +31,9 @@ class Group {
 
 @jsonSerializable
 class Manager extends User {
+  @jsonSerializable
   external Map<String, Object?> toJson();
+  @jsonSerializable
   external Manager.fromJson(Map<String, Object?> json);
   final List<User> reports;
   Manager({required String name, required this.reports}) : super(name: name);

--- a/lib/src/declarations.dart
+++ b/lib/src/declarations.dart
@@ -13,24 +13,12 @@ abstract class TypeDeclaration implements TypeReference, DeclarationType {
   bool isSubtype(TypeDeclaration other);
 }
 
-abstract class TargetTypeDeclaration extends TypeDeclaration {
+abstract class ClassDeclaration extends TypeDeclaration {
   Iterable<MethodDeclaration> get constructors;
 
   Iterable<FieldDeclaration> get fields;
 
   Iterable<MethodDeclaration> get methods;
-}
-
-abstract class TargetClassDeclaration implements TargetTypeDeclaration {
-  Iterable<TargetMethodDeclaration> get constructors;
-
-  Iterable<TargetFieldDeclaration> get fields;
-
-  Iterable<TargetMethodDeclaration> get methods;
-
-  void addToClass(Code declaration);
-
-  void addToLibrary(Code declaration);
 }
 
 abstract class MethodDeclaration implements MethodType {
@@ -43,18 +31,10 @@ abstract class MethodDeclaration implements MethodType {
   Iterable<TypeParameterDeclaration> get typeParameters;
 }
 
-abstract class TargetMethodDeclaration implements MethodDeclaration {
-  void addToClass(Code declaration);
-}
-
 abstract class FieldDeclaration implements FieldType {
   String get name;
 
   TypeDeclaration get type;
-}
-
-abstract class TargetFieldDeclaration implements FieldDeclaration {
-  void addToClass(Code declaration);
 }
 
 abstract class ParameterDeclaration implements ParameterType {
@@ -63,4 +43,15 @@ abstract class ParameterDeclaration implements ParameterType {
 
 abstract class TypeParameterDeclaration implements TypeParameterType {
   TypeDeclaration? get bounds;
+}
+
+abstract class DeclarationBuilder {
+  void addToLibrary(Code declaration);
+}
+
+abstract class ClassDeclarationBuilder implements DeclarationBuilder {
+  // TODO: If we want library level macros that can have a declaration phase
+  // that adds stuff to classes, then this should take a parameter to identify
+  // which class [declaration] should be added to.
+  void addToClass(Code declaration);
 }

--- a/lib/src/declarations.dart
+++ b/lib/src/declarations.dart
@@ -2,10 +2,6 @@ import 'code.dart';
 import 'types.dart';
 
 abstract class TypeDeclaration implements TypeReference, DeclarationType {
-  TypeDeclaration? get superclass;
-
-  Iterable<TypeDeclaration> get superinterfaces;
-
   Iterable<TypeDeclaration> get typeArguments;
 
   Iterable<TypeParameterDeclaration> get typeParameters;
@@ -13,12 +9,16 @@ abstract class TypeDeclaration implements TypeReference, DeclarationType {
   bool isSubtype(TypeDeclaration other);
 }
 
-abstract class ClassDeclaration extends TypeDeclaration {
+abstract class ClassDeclaration implements TypeDeclaration, ClassType {
   Iterable<MethodDeclaration> get constructors;
 
   Iterable<FieldDeclaration> get fields;
 
   Iterable<MethodDeclaration> get methods;
+
+  TypeDeclaration? get superclass;
+
+  Iterable<TypeDeclaration> get superinterfaces;
 }
 
 abstract class MethodDeclaration implements MethodType {

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -2,30 +2,26 @@ import 'code.dart';
 import 'declarations.dart';
 
 abstract class TypeDefinition implements TypeDeclaration {
-  Iterable<MethodDefinition> get constructors;
-
-  Iterable<FieldDefinition> get fields;
-
-  Iterable<MethodDefinition> get methods;
-
-  TypeDefinition? get superclass;
-
-  Iterable<TypeDefinition> get superinterfaces;
-
   Iterable<TypeDefinition> get typeArguments;
 
   Iterable<TypeParameterDefinition> get typeParameters;
 }
 
-abstract class ClassDefinition implements TypeDefinition {
+abstract class ClassDefinition implements TypeDefinition, ClassDeclaration {
   Iterable<MethodDefinition> get constructors;
 
   Iterable<MethodDefinition> get methods;
 
   Iterable<FieldDefinition> get fields;
+
+  TypeDefinition? get superclass;
+
+  Iterable<TypeDefinition> get superinterfaces;
 }
 
 abstract class MethodDefinition implements MethodDeclaration {
+  ClassDefinition? get definingClass;
+
   String get name;
 
   TypeDefinition get returnType;
@@ -38,6 +34,8 @@ abstract class MethodDefinition implements MethodDeclaration {
 }
 
 abstract class FieldDefinition implements FieldDeclaration {
+  ClassDefinition? get definingClass;
+
   String get name;
 
   TypeDefinition get type;

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -17,12 +17,12 @@ abstract class TypeDefinition implements TypeDeclaration {
   Iterable<TypeParameterDefinition> get typeParameters;
 }
 
-abstract class TargetClassDefinition implements TypeDefinition {
-  Iterable<TargetMethodDefinition> get constructors;
+abstract class ClassDefinition implements TypeDefinition {
+  Iterable<MethodDefinition> get constructors;
 
-  Iterable<TargetMethodDefinition> get methods;
+  Iterable<MethodDefinition> get methods;
 
-  Iterable<TargetFieldDefinition> get fields;
+  Iterable<FieldDefinition> get fields;
 }
 
 abstract class MethodDefinition implements MethodDeclaration {
@@ -37,17 +37,21 @@ abstract class MethodDefinition implements MethodDeclaration {
   Iterable<TypeParameterDefinition> get typeParameters;
 }
 
-abstract class TargetMethodDefinition implements MethodDefinition {
-  void implement(Code body, {List<Code>? supportingDeclarations});
-}
-
 abstract class FieldDefinition implements FieldDeclaration {
   String get name;
 
   TypeDefinition get type;
 }
 
-abstract class TargetFieldDefinition implements FieldDefinition {
+abstract class ParameterDefinition implements ParameterDeclaration {
+  TypeDefinition get type;
+}
+
+abstract class TypeParameterDefinition implements TypeParameterDeclaration {
+  TypeDefinition? get bounds;
+}
+
+abstract class FieldDefinitionBuilder {
   /// Implement this as a normal field and supply an initializer.
   void withInitializer(Code body, {List<Code>? supportingDeclarations});
 
@@ -57,10 +61,6 @@ abstract class TargetFieldDefinition implements FieldDefinition {
       {List<Code>? supportingDeclarations});
 }
 
-abstract class ParameterDefinition implements ParameterDeclaration {
-  TypeDefinition get type;
-}
-
-abstract class TypeParameterDefinition implements TypeParameterDeclaration {
-  TypeDefinition? get bounds;
+abstract class MethodDefinitionBuilder {
+  void implement(Code body, {List<Code>? supportingDeclarations});
 }

--- a/lib/src/macro.dart
+++ b/lib/src/macro.dart
@@ -4,43 +4,45 @@ import 'types.dart';
 
 abstract class Macro {}
 
+abstract class TypeMacro implements Macro {}
+
+abstract class DeclarationMacro implements Macro {}
+
+abstract class DefinitionMacro implements Macro {}
+
 abstract class ClassTypeMacro implements TypeMacro {
-  void type(ClassType type, TypeBuilder builder);
+  void visitClassType(ClassType type, TypeBuilder builder);
 }
 
 abstract class ClassDeclarationMacro implements DeclarationMacro {
-  void declare(ClassDeclaration declaration, ClassDeclarationBuilder builder);
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
-// This isn't needed. Instead, a class-level macro that adds members
-// must implement FieldDefinitionMacro and/or MethodDefinitionMacro and then
-// has those invoked directly for the members it has declared.
-//
-// A macro that declares a member is committing itself to defining it later.
-// abstract class ClassDefinitionMacro implements DefinitionMacro {
-//   void define(TargetClassDefinition definition);
-// }
-
 abstract class FieldTypeMacro implements TypeMacro {
-  void type(FieldType type, TypeBuilder builder);
+  void visitFieldType(FieldType type, TypeBuilder builder);
 }
 
 abstract class FieldDeclarationMacro implements DeclarationMacro {
-  void declare(FieldDeclaration declaration, ClassDeclarationBuilder builder);
+  void visitFieldDeclaration(
+      FieldDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 abstract class FieldDefinitionMacro implements DefinitionMacro {
-  void define(FieldDefinition definition, FieldDefinitionBuilder builder);
+  void visitFieldDefinition(
+      FieldDefinition definition, FieldDefinitionBuilder builder);
 }
 
 abstract class MethodTypeMacro implements TypeMacro {
-  void type(MethodType type, TypeBuilder builder);
+  void visitMethodType(MethodType type, TypeBuilder builder);
 }
 
 abstract class MethodDeclarationMacro implements DeclarationMacro {
-  void declare(MethodDeclaration declaration, ClassDeclarationBuilder builder);
+  void visitMethodDeclaration(
+      MethodDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 abstract class MethodDefinitionMacro implements DefinitionMacro {
-  void define(MethodDefinition definition MethodDefinitionBuilder builder);
+  void visitMethodDefinition(
+      MethodDefinition definition, MethodDefinitionBuilder builder);
 }

--- a/lib/src/macro.dart
+++ b/lib/src/macro.dart
@@ -4,44 +4,43 @@ import 'types.dart';
 
 abstract class Macro {}
 
-abstract class TypeMacro implements Macro {}
-
-abstract class DeclarationMacro implements Macro {}
-
-abstract class DefinitionMacro implements Macro {}
-
 abstract class ClassTypeMacro implements TypeMacro {
-  void type(TargetClassType type);
+  void type(ClassType type, TypeBuilder builder);
 }
 
 abstract class ClassDeclarationMacro implements DeclarationMacro {
-  void declare(TargetClassDeclaration declaration);
+  void declare(ClassDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
-abstract class ClassDefinitionMacro implements DefinitionMacro {
-  void define(TargetClassDefinition definition);
-}
+// This isn't needed. Instead, a class-level macro that adds members
+// must implement FieldDefinitionMacro and/or MethodDefinitionMacro and then
+// has those invoked directly for the members it has declared.
+//
+// A macro that declares a member is committing itself to defining it later.
+// abstract class ClassDefinitionMacro implements DefinitionMacro {
+//   void define(TargetClassDefinition definition);
+// }
 
 abstract class FieldTypeMacro implements TypeMacro {
-  void type(TargetFieldType type);
+  void type(FieldType type, TypeBuilder builder);
 }
 
 abstract class FieldDeclarationMacro implements DeclarationMacro {
-  void declare(TargetFieldDeclaration declaration);
+  void declare(FieldDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 abstract class FieldDefinitionMacro implements DefinitionMacro {
-  void define(TargetFieldDefinition definition);
+  void define(FieldDefinition definition, FieldDefinitionBuilder builder);
 }
 
 abstract class MethodTypeMacro implements TypeMacro {
-  void type(TargetMethodType type);
+  void type(MethodType type, TypeBuilder builder);
 }
 
 abstract class MethodDeclarationMacro implements DeclarationMacro {
-  void declare(TargetMethodDeclaration declaration);
+  void declare(MethodDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 abstract class MethodDefinitionMacro implements DefinitionMacro {
-  void define(TargetMethodDefinition definition);
+  void define(MethodDefinition definition MethodDefinitionBuilder builder);
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -20,7 +20,9 @@ abstract class DeclarationType {
 }
 
 abstract class ClassType implements TypeReference, DeclarationType {
-  // TODO: Get TypeReferences for superclass and superinterfaces?
+  TypeReference? get superclass;
+
+  Iterable<TypeReference> get superinterfaces;
 }
 
 abstract class MethodType implements DeclarationType {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -19,8 +19,8 @@ abstract class DeclarationType {
   String get name;
 }
 
-abstract class TargetClassType implements TypeReference, DeclarationType {
-  void addTypeToLibary(Code declaration);
+abstract class ClassType implements TypeReference, DeclarationType {
+  // TODO: Get TypeReferences for superclass and superinterfaces?
 }
 
 abstract class MethodType implements DeclarationType {
@@ -37,16 +37,8 @@ abstract class MethodType implements DeclarationType {
   Iterable<TypeParameterType> get typeParameters;
 }
 
-abstract class TargetMethodType implements MethodType {
-  void addTypeToLibary(Code declaration);
-}
-
 abstract class FieldType implements DeclarationType {
   TypeReference get type;
-}
-
-abstract class TargetFieldType implements FieldType {
-  void addTypeToLibary(Code declaration);
 }
 
 abstract class ParameterType {
@@ -61,4 +53,8 @@ abstract class TypeParameterType {
   TypeReference? get bounds;
 
   String get name;
+}
+
+abstract class TypeBuilder {
+  void addTypeToLibary(Code declaration);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ dependencies:
   build: ^2.0.0
   dart_style: ^2.0.0
   source_gen: ^1.0.2
+  pedantic: ^1.0.0
 dev_dependencies:
   build_runner: ^2.0.0
 dependency_overrides:


### PR DESCRIPTION
(You don't have to land this. Just sending a PR to get your attention. :) )

Here's a rough proposal for how it could look to move the mutation side
of the macro API to objects that are passed separately to the macro.
This means there is no longer a need to maintain separate pairs of Foo
and TargetFoo classes.

I don't think it's a huge win in this PR, but as these APIs fill out
with more members, I think the separation would become more valuable.