### PR TITLE
add initial autoListenable macro for fields

### DIFF
--- a/example/macros/data_class.dart
+++ b/example/macros/data_class.dart
@@ -101,11 +101,11 @@ class _CopyWith implements ClassDeclarationMacro {
     builder.addToClass(Declaration.fromParts([
       declaration.reference,
       Fragment(' copyWith({'),
-      namedParams,
+      Fragment.fromParts(namedParams, ', '),
       Fragment('})'),
       // TODO: We assume this constructor exists, but should check
       Fragment('=> ${declaration.reference}('),
-      args,
+      Fragment.fromParts(args, ', '),
       Fragment(');'),
     ]));
   }

--- a/example/macros/json.dart
+++ b/example/macros/json.dart
@@ -68,8 +68,7 @@ class _JsonMacro
       entries.add(Fragment(
           '  "${field.name}": ${_typeToJson(field.type, Fragment(field.name))}, '));
     }
-    var body =
-        FunctionBody.fromParts(['=> <String, Object?>{', ...entries, '};']);
+    var body = FunctionBody.fromParts(['=> <String, Object?>{', entries, '};']);
     builder.implement(body);
   }
 

--- a/flutter_example/lib/builders.dart
+++ b/flutter_example/lib/builders.dart
@@ -2,10 +2,12 @@ import 'package:build/build.dart';
 import 'package:macro_builder/builder.dart';
 
 import 'macros/auto_dispose.dart';
+import 'macros/auto_listenable.dart';
 import 'macros/functional_widget.dart';
 import 'macros/render_accessors.dart';
 
-Builder typesBuilder(_) => TypesMacroBuilder([widget]);
-Builder declarationsBuilder(_) =>
-    DeclarationsMacroBuilder([autoDispose, const RenderAccessors()]);
-Builder definitionsBuilder(_) => DefinitionsMacroBuilder([autoDispose]);
+Builder typesBuilder(_) => TypesMacroBuilder([fwidget]);
+Builder declarationsBuilder(_) => DeclarationsMacroBuilder(
+    [autoDispose, const RenderAccessors(), autoListenable]);
+Builder definitionsBuilder(_) =>
+    DefinitionsMacroBuilder([autoDispose, autoListenable]);

--- a/flutter_example/lib/macros/auto_dispose.dart
+++ b/flutter_example/lib/macros/auto_dispose.dart
@@ -43,7 +43,7 @@ external void dispose();
     // prepend extra calls.
     if (definition.isAbstract || definition.isExternal) {
       builder.implement(FunctionBody.fromParts(
-          ['{', Statement('super.dispose();'), ...disposeCalls, '}']));
+          ['{', Statement('super.dispose();'), disposeCalls, '}']));
     } else {
       builder.wrapBody(before: disposeCalls);
     }

--- a/flutter_example/lib/macros/auto_listenable.dart
+++ b/flutter_example/lib/macros/auto_listenable.dart
@@ -1,0 +1,212 @@
+import 'package:macro_builder/definition.dart';
+import 'package:collection/collection.dart';
+
+const autoListenable = AutoListenable();
+
+class AutoListenable implements ClassDeclarationMacro, MethodDefinitionMacro {
+  const AutoListenable();
+
+  /// In this phase we add overrides to all desired methods and apply ourself
+  /// to them.
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) {
+    // TODO: https://github.com/jakemac53/macro_prototype/issues/33
+    if (!declaration.hackyIsSubtypeOf('State')) {
+      throw ArgumentError('@autoListenable can only be used on State classes');
+    }
+    var widgetClass = declaration.widgetClass;
+
+    if (declaration.initState == null) {
+      builder.addToClass(Declaration('''
+@override
+@autoListenable
+external void initState();
+'''));
+    } else {
+      // https://github.com/jakemac53/macro_prototype/issues/34
+      throw ArgumentError(
+          '@autoListenable isn\'t compatible with a custom `initState` '
+          'method.');
+    }
+
+    if (declaration.didUpdateWidget == null) {
+      builder.addToClass(Declaration.fromParts([
+        '''
+@override
+@autoListenable
+external void didUpdateWidget(
+  ''',
+        widgetClass.reference,
+        ' oldWidget);'
+      ]));
+    } else {
+      // https://github.com/jakemac53/macro_prototype/issues/34
+      throw ArgumentError(
+          '@autoListenable isn\'t compatible with a custom `didUpdateWidget` '
+          'method.');
+    }
+
+    if (declaration.dispose == null) {
+      builder.addToClass(Declaration('''
+@override
+@autoListenable
+external void dispose();
+'''));
+    } else {
+      // https://github.com/jakemac53/macro_prototype/issues/34, we comment
+      // this check out for now and manually add a macro application in the\
+      // user code.
+      //
+      // throw ArgumentError(
+      //     '@autoListenable isn\'t compatible with a custom `dispose` method.');
+    }
+  }
+
+  /// Here we actually implement each method, by looking at the fields on the
+  /// widget class.
+  @override
+  void visitMethodDefinition(
+      MethodDefinition definition, FunctionDefinitionBuilder builder) {
+    var widgetClass = definition.definingClass.widgetClass;
+
+    switch (definition.name) {
+      case 'initState':
+        _buildInitState(definition, widgetClass, builder);
+        break;
+      case 'didUpdateWidget':
+        _buildDidUpdateWidget(definition, widgetClass, builder);
+        break;
+      case 'dispose':
+        _buildDispose(definition, widgetClass, builder);
+        break;
+    }
+  }
+
+  void _buildInitState(MethodDefinition definition,
+      ClassDeclaration widgetClass, FunctionDefinitionBuilder builder) {
+    var statements = [
+      if (definition.isExternal) Statement('super.initState();'),
+    ];
+    for (var field in widgetClass.fields) {
+      // TODO: https://github.com/jakemac53/macro_prototype/issues/33
+      if (!field.type.hackyIsSubtypeOf('Listenable')) continue;
+      var handler = _handler(field, definition.definingClass, widgetClass);
+      var questionMark = field.type.isNullable ? '?' : '';
+      statements.add(Statement(
+          'widget.${field.name}$questionMark.addListener($handler);'));
+    }
+    if (definition.isExternal) {
+      builder.implement(FunctionBody.fromParts(['{', statements, '}']));
+    } else {
+      builder.wrapBody(after: statements);
+    }
+  }
+
+  void _buildDidUpdateWidget(MethodDefinition definition,
+      ClassDeclaration widgetClass, FunctionDefinitionBuilder builder) {
+    var parts = <Statement>[
+      if (definition.isExternal) Statement('super.didUpdateWidget(oldWidget);'),
+    ];
+    for (var field in widgetClass.fields) {
+      // TODO: https://github.com/jakemac53/macro_prototype/issues/33
+      if (!field.type.hackyIsSubtypeOf('Listenable')) continue;
+      var handler = _handler(field, definition.definingClass, widgetClass);
+      var questionMark = field.type.isNullable ? '?' : '';
+      var widgetField = Fragment('widget.${field.name}$questionMark');
+      var oldWidgetField = Fragment('oldWidget.${field.name}$questionMark');
+      parts.add(Statement.fromParts([
+        'if ($widgetField != $oldWidgetField) {',
+        Statement('$oldWidgetField.removeListener($handler);'),
+        Statement('$widgetField.addListener($handler);'),
+        '}'
+      ]));
+    }
+    if (definition.isExternal) {
+      builder.implement(FunctionBody.fromParts(['{', parts, '}']));
+    } else {
+      builder.wrapBody(after: parts);
+    }
+  }
+
+  void _buildDispose(MethodDefinition definition, ClassDeclaration widgetClass,
+      FunctionDefinitionBuilder builder) {
+    var parts = <Statement>[
+      Statement('super.dispose();'),
+    ];
+    for (var field in widgetClass.fields) {
+      // TODO: https://github.com/jakemac53/macro_prototype/issues/33
+      if (!field.type.hackyIsSubtypeOf('Listenable')) continue;
+      var handler = _handler(field, definition.definingClass, widgetClass);
+      var questionMark = field.type.isNullable ? '?' : '';
+      parts.add(Statement(
+          'widget.${field.name}$questionMark.removeListener($handler);'));
+    }
+    if (definition.isExternal) {
+      builder.implement(FunctionBody.fromParts(['{', parts, '}']));
+    } else {
+      builder.wrapBody(after: parts);
+    }
+  }
+
+  /// Returns the expected handler name for [field], and throws if that handler
+  /// does not exist on [stateClass].
+  String _handler(FieldDeclaration field, ClassDeclaration stateClass,
+      ClassDeclaration widgetClass) {
+    var handlerName =
+        '_handle${field.name[0].toUpperCase()}${field.name.substring(1)}';
+    var handler =
+        stateClass.methods.firstWhereOrNull((m) => m.name == handlerName);
+    if (handler == null) {
+      throw ArgumentError('Missing handler function `$handler` in '
+          '${stateClass.name} for listenable field '
+          '${field.name} from widget class ${widgetClass.name}.');
+    }
+    if (handler.positionalParameters.where((p) => p.required).isNotEmpty ||
+        handler.namedParameters.values.where((p) => p.required).isNotEmpty) {
+      throw ArgumentError(
+          'Handler ${handler.name} did not match the expected signature, it '
+          'should have no required parameters.');
+    }
+    return handlerName;
+  }
+}
+
+extension on ClassDeclaration {
+  MethodDeclaration? get initState =>
+      methods.firstWhereOrNull((m) => m.name == 'initState');
+
+  MethodDeclaration? get didUpdateWidget =>
+      methods.firstWhereOrNull((m) => m.name == 'didUpdateWidget');
+
+  MethodDeclaration? get dispose =>
+      methods.firstWhereOrNull((m) => m.name == 'dispose');
+}
+
+extension on TypeDeclaration {
+  bool hackyIsSubtypeOf(String type) {
+    if (name == type) return true;
+    if (this is ClassDeclaration) {
+      for (var interface in (this as ClassDeclaration).superinterfaces) {
+        if (interface.name == type) return true;
+      }
+    }
+    return false;
+  }
+}
+
+extension on ClassDeclaration {
+  ClassDeclaration get widgetClass {
+    ClassDeclaration next = this;
+    while (true) {
+      if (next.name == 'State') {
+        return next.typeArguments.first as ClassDeclaration;
+      }
+      var superClass = next.superclass;
+      if (superClass == null) {
+        throw StateError('Unable to find widget class for state class $name');
+      }
+      next = superClass;
+    }
+  }
+}

--- a/flutter_example/lib/macros/auto_listenable.dart
+++ b/flutter_example/lib/macros/auto_listenable.dart
@@ -54,12 +54,9 @@ external void didUpdateWidget(
 external void dispose();
 '''));
     } else {
-      // https://github.com/jakemac53/macro_prototype/issues/34, we comment
-      // this check out for now and manually add a macro application in the\
-      // user code.
-      //
-      // throw ArgumentError(
-      //     '@autoListenable isn\'t compatible with a custom `dispose` method.');
+      // https://github.com/jakemac53/macro_prototype/issues/34
+      throw ArgumentError(
+          '@autoListenable isn\'t compatible with a custom `dispose` method.');
     }
   }
 

--- a/flutter_example/lib/macros/auto_listenable.dart
+++ b/flutter_example/lib/macros/auto_listenable.dart
@@ -128,9 +128,7 @@ external void dispose();
 
   void _buildDispose(MethodDefinition definition, ClassDeclaration widgetClass,
       FunctionDefinitionBuilder builder) {
-    var parts = <Statement>[
-      Statement('super.dispose();'),
-    ];
+    var parts = <Statement>[];
     for (var field in widgetClass.fields) {
       // TODO: https://github.com/jakemac53/macro_prototype/issues/33
       if (!field.type.hackyIsSubtypeOf('Listenable')) continue;
@@ -140,9 +138,9 @@ external void dispose();
           'widget.${field.name}$questionMark.removeListener($handler);'));
     }
     if (definition.isExternal) {
-      builder.implement(FunctionBody.fromParts(['{', parts, '}']));
+      builder.implement(FunctionBody.fromParts(['{', parts, Statement('super.dispose();'), '}']));
     } else {
-      builder.wrapBody(after: parts);
+      builder.wrapBody(before: parts);
     }
   }
 

--- a/flutter_example/lib/macros/functional_widget.dart
+++ b/flutter_example/lib/macros/functional_widget.dart
@@ -1,6 +1,6 @@
 import 'package:macro_builder/definition.dart';
 
-const widget = FunctionalWidget();
+const fwidget = FunctionalWidget();
 
 class FunctionalWidget implements FunctionTypeMacro {
   final String? widgetName;
@@ -40,7 +40,7 @@ class FunctionalWidget implements FunctionTypeMacro {
       Fragment('Key? key, }'),
     ];
     var constructor = Declaration.fromParts(
-        ['const $widgetName(', ...constructorArgs, ') : super(key: key);']);
+        ['const $widgetName(', constructorArgs, ') : super(key: key);']);
     var invocationArgs = <Code>[
       for (var param in positionalFieldParams) Fragment('${param.name}, '),
       for (var param in declaration.namedParameters.values)
@@ -51,13 +51,13 @@ class FunctionalWidget implements FunctionTypeMacro {
 @override
 Widget build(BuildContext context) =>
     ${declaration.name}(context, ''',
-      ...invocationArgs,
+      invocationArgs,
       ');',
     ]);
 
     builder.addTypeToLibary(Declaration.fromParts([
       'class $widgetName extends StatelessWidget {',
-      ...fields,
+      fields,
       constructor,
       buildMethod,
       '}',

--- a/flutter_example/lib/main.dart
+++ b/flutter_example/lib/main.dart
@@ -48,8 +48,8 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   @autoListenable
   void dispose() {
-    super.dispose();
     widget.counter.removeListener(_handleCounter);
+    super.dispose();
   }
 
   void _incrementCounter() {

--- a/flutter_example/lib/main.declarations.dart
+++ b/flutter_example/lib/main.declarations.dart
@@ -5,29 +5,45 @@
 //
 //   - Instance of '_AutoDisposeMacro'
 //   - Instance of 'RenderAccessors'
+//   - Instance of 'AutoListenable'
 //
 // To make changes you should edit the `lib/main.gen.dart` file;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'macros/auto_dispose.dart';
+import 'macros/auto_listenable.dart';
 import 'macros/functional_widget.dart';
 import 'macros/render_accessors.dart';
 
 class MyHomePage extends StatefulWidget {
+  final ValueNotifier<int> counter;
   final String title;
   @override
   State<MyHomePage> createState() => _MyHomePageState();
-  const MyHomePage({Key? key, required this.title}) : super(key: key);
+  const MyHomePage(this.counter, {Key? key, required this.title})
+      : super(key: key);
 }
 
+@autoListenable
 class _MyHomePageState extends State<MyHomePage> {
-  final disposable = SimpleDisposable();
-  int _counter = 0;
+  @override
+  @autoListenable
+  external void initState();
+
+  @override
+  @autoListenable
+  external void didUpdateWidget(MyHomePage oldWidget);
+  @override
+  @autoListenable
+  external void dispose();
+
   Color _color = Colors.blue;
   void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
+    widget.counter.value++;
+  }
+
+  void _handleCounter() {
+    setState(() {});
   }
 
   @override
@@ -39,7 +55,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
               const Text('You have pushed the button this many times:'),
-              Text('$_counter', style: Theme.of(context).textTheme.headline4),
+              Text('${widget.counter.value}',
+                  style: Theme.of(context).textTheme.headline4),
               GestureDetector(
                   onTap: () {
                     setState(() {
@@ -55,19 +72,6 @@ class _MyHomePageState extends State<MyHomePage> {
             onPressed: _incrementCounter,
             tooltip: 'Increment',
             child: const Icon(Icons.add)));
-  }
-
-  @override
-  @autoDispose
-  void dispose() {
-    super.dispose();
-  }
-}
-
-class SimpleDisposable implements Disposable {
-  @override
-  void dispose() {
-    print('disposing $this');
   }
 }
 
@@ -117,23 +121,27 @@ class MyColoredFillRenderBox extends RenderBox {
 }
 
 class MyApp extends StatelessWidget {
+  final ValueNotifier<int> counter;
   final String? appTitle;
   final String? homePageTitle;
   @override
-  Widget build(BuildContext context) =>
-      _buildApp(context, appTitle: appTitle, homePageTitle: homePageTitle);
-  const MyApp({this.appTitle, this.homePageTitle, Key? key}) : super(key: key);
+  Widget build(BuildContext context) => _buildApp(context, counter,
+      appTitle: appTitle, homePageTitle: homePageTitle);
+  const MyApp(this.counter, {this.appTitle, this.homePageTitle, Key? key})
+      : super(key: key);
 }
 
 void main() {
-  runApp(const MyApp());
+  var counterNotifier = ValueNotifier<int>(0);
+  runApp(MyApp(counterNotifier));
 }
 
 @FunctionalWidget(widgetName: 'MyApp')
-Widget _buildApp(BuildContext context,
+Widget _buildApp(BuildContext context, ValueNotifier<int> counter,
     {String? appTitle, String? homePageTitle}) {
   return MaterialApp(
       title: appTitle ?? 'Flutter Demo',
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: MyHomePage(title: homePageTitle ?? 'Flutter Demo Home Page'));
+      home: MyHomePage(counter,
+          title: homePageTitle ?? 'Flutter Demo Home Page'));
 }

--- a/flutter_example/lib/main.gen.dart
+++ b/flutter_example/lib/main.gen.dart
@@ -41,7 +41,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   void _handleCounter() {
-    setState(() {});
+    setState(() { /* wiget.counter.value is used in the build method */});
   }
 
   @override

--- a/flutter_example/lib/main.gen.dart
+++ b/flutter_example/lib/main.gen.dart
@@ -1,24 +1,30 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'macros/auto_dispose.dart';
+import 'macros/auto_listenable.dart';
 import 'macros/functional_widget.dart';
 import 'macros/render_accessors.dart';
 
 void main() {
-  runApp(const MyApp());
+  var counterNotifier = ValueNotifier<int>(0);
+  runApp(MyApp(counterNotifier));
 }
 
 @FunctionalWidget(widgetName: 'MyApp')
-Widget _buildApp(BuildContext context,
+Widget _buildApp(BuildContext context, ValueNotifier<int> counter,
     {String? appTitle, String? homePageTitle}) {
   return MaterialApp(
       title: appTitle ?? 'Flutter Demo',
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: MyHomePage(title: homePageTitle ?? 'Flutter Demo Home Page'));
+      home: MyHomePage(counter,
+          title: homePageTitle ?? 'Flutter Demo Home Page'));
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, required this.title}) : super(key: key);
+  final ValueNotifier<int> counter;
+
+  const MyHomePage(this.counter, {Key? key, required this.title})
+      : super(key: key);
 
   final String title;
 
@@ -26,15 +32,16 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
+@autoListenable
 class _MyHomePageState extends State<MyHomePage> {
-  final disposable = SimpleDisposable();
-  int _counter = 0;
   Color _color = Colors.blue;
 
   void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
+    widget.counter.value++;
+  }
+
+  void _handleCounter() {
+    setState(() {});
   }
 
   @override
@@ -51,7 +58,7 @@ class _MyHomePageState extends State<MyHomePage> {
               'You have pushed the button this many times:',
             ),
             Text(
-              '$_counter',
+              '${widget.counter.value}',
               style: Theme.of(context).textTheme.headline4,
             ),
             GestureDetector(
@@ -77,19 +84,6 @@ class _MyHomePageState extends State<MyHomePage> {
         child: const Icon(Icons.add),
       ),
     );
-  }
-
-  @override
-  @autoDispose
-  void dispose() {
-    super.dispose();
-  }
-}
-
-class SimpleDisposable implements Disposable {
-  @override
-  void dispose() {
-    print('disposing $this');
   }
 }
 

--- a/flutter_example/lib/main.types.dart
+++ b/flutter_example/lib/main.types.dart
@@ -7,26 +7,30 @@
 //
 // To make changes you should edit the `lib/main.gen.dart` file;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'macros/auto_dispose.dart';
+import 'macros/auto_listenable.dart';
 import 'macros/functional_widget.dart';
 import 'macros/render_accessors.dart';
 
 class MyHomePage extends StatefulWidget {
+  final ValueNotifier<int> counter;
   final String title;
   @override
   State<MyHomePage> createState() => _MyHomePageState();
-  const MyHomePage({Key? key, required this.title}) : super(key: key);
+  const MyHomePage(this.counter, {Key? key, required this.title})
+      : super(key: key);
 }
 
+@autoListenable
 class _MyHomePageState extends State<MyHomePage> {
-  final disposable = SimpleDisposable();
-  int _counter = 0;
   Color _color = Colors.blue;
   void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
+    widget.counter.value++;
+  }
+
+  void _handleCounter() {
+    setState(() {});
   }
 
   @override
@@ -38,7 +42,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
               const Text('You have pushed the button this many times:'),
-              Text('$_counter', style: Theme.of(context).textTheme.headline4),
+              Text('${widget.counter.value}',
+                  style: Theme.of(context).textTheme.headline4),
               GestureDetector(
                   onTap: () {
                     setState(() {
@@ -54,19 +59,6 @@ class _MyHomePageState extends State<MyHomePage> {
             onPressed: _incrementCounter,
             tooltip: 'Increment',
             child: const Icon(Icons.add)));
-  }
-
-  @override
-  @autoDispose
-  void dispose() {
-    super.dispose();
-  }
-}
-
-class SimpleDisposable implements Disposable {
-  @override
-  void dispose() {
-    print('disposing $this');
   }
 }
 
@@ -107,13 +99,16 @@ class MyColoredFillRenderBox extends RenderBox {
 }
 
 void main() {
-  runApp(const MyApp());
+  var counterNotifier = ValueNotifier<int>(0);
+  runApp(MyApp(counterNotifier));
 }
 
 class MyApp extends StatelessWidget {
+  final ValueNotifier<int> counter;
   final String? appTitle;
   final String? homePageTitle;
-  const MyApp({
+  const MyApp(
+    this.counter, {
     this.appTitle,
     this.homePageTitle,
     Key? key,
@@ -121,16 +116,18 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) => _buildApp(
         context,
+        counter,
         appTitle: appTitle,
         homePageTitle: homePageTitle,
       );
 }
 
 @FunctionalWidget(widgetName: 'MyApp')
-Widget _buildApp(BuildContext context,
+Widget _buildApp(BuildContext context, ValueNotifier<int> counter,
     {String? appTitle, String? homePageTitle}) {
   return MaterialApp(
       title: appTitle ?? 'Flutter Demo',
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: MyHomePage(title: homePageTitle ?? 'Flutter Demo Home Page'));
+      home: MyHomePage(counter,
+          title: homePageTitle ?? 'Flutter Demo Home Page'));
 }

--- a/flutter_example/pubspec.yaml
+++ b/flutter_example/pubspec.yaml
@@ -28,6 +28,7 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   build: ^2.0.0
+  collection: ^1.15.0
   flutter:
     sdk: flutter
 

--- a/flutter_example/test/widget_test.dart
+++ b/flutter_example/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_example/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp(ValueNotifier<int>(0)));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);

--- a/lib/src/code.dart
+++ b/lib/src/code.dart
@@ -30,9 +30,9 @@ class Fragment extends Code {
   /// Creates a [Fragment] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory Fragment.fromParts(List<Object> parts) =>
-      Fragment(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory Fragment.fromParts(List<Object> parts, [String separator = '']) =>
+      Fragment(_combineParts(parts, separator));
 }
 
 /// A piece of code representing a syntactically valid Declaration.
@@ -51,9 +51,9 @@ class Declaration extends Code {
   /// Creates a [Declaration] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory Declaration.fromParts(List<Object> parts) =>
-      Declaration(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory Declaration.fromParts(List<Object> parts, [String separator = '']) =>
+      Declaration(_combineParts(parts, separator));
 }
 
 /// A piece of code representing a syntactically valid Element.
@@ -72,9 +72,9 @@ class Element extends Code {
   /// Creates a [Declaration] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory Element.fromParts(List<Object> parts) =>
-      Element(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory Element.fromParts(List<Object> parts, [String separator = '']) =>
+      Element(_combineParts(parts, separator));
 }
 
 /// A piece of code representing a syntactically valid Expression.
@@ -95,9 +95,9 @@ class Expression extends Code {
   /// Creates an [Expression] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory Expression.fromParts(List<Object> parts) =>
-      Expression(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory Expression.fromParts(List<Object> parts, [String separator = '']) =>
+      Expression(_combineParts(parts, separator));
 }
 
 /// A piece of code representing a syntactically valid function body.
@@ -125,9 +125,9 @@ class FunctionBody extends Code {
   /// Creates an [Expression] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory FunctionBody.fromParts(List<Object> parts) =>
-      FunctionBody(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory FunctionBody.fromParts(List<Object> parts, [String separator = '']) =>
+      FunctionBody(_combineParts(parts, separator));
 }
 
 /// A piece of code identifying a named argument.
@@ -148,9 +148,10 @@ class NamedArgument extends Code {
   /// Creates a [Parameter] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory NamedArgument.fromParts(List<Object> parts) =>
-      NamedArgument(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory NamedArgument.fromParts(List<Object> parts,
+          [String separator = '']) =>
+      NamedArgument(_combineParts(parts, separator));
 }
 
 /// A piece of code identifying a syntactically valid function parameter.
@@ -177,9 +178,9 @@ class Parameter extends Code {
   /// Creates a [Parameter] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory Parameter.fromParts(List<Object> parts) =>
-      Parameter(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory Parameter.fromParts(List<Object> parts, [String separator = '']) =>
+      Parameter(_combineParts(parts, separator));
 }
 
 /// A piece of code representing a syntactically valid statement.
@@ -200,9 +201,9 @@ class Statement extends Code {
   /// Creates a [Statement] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory Statement.fromParts(List<Object> parts) =>
-      Statement(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory Statement.fromParts(List<Object> parts, [String separator = '']) =>
+      Statement(_combineParts(parts, separator));
 }
 
 /// A piece of code representing a syntactically valid type annotation.
@@ -225,9 +226,10 @@ class TypeAnnotation extends Code {
   /// Creates a [TypeAnnotation] from [parts], which must be of type [Code]
   /// [List<Code>] or [String].
   ///
-  /// When a [List<Code>] is encountered they are joined by a comma.
-  factory TypeAnnotation.fromParts(List<Object> parts) =>
-      TypeAnnotation(_combineParts(parts));
+  /// When a [List<Code>] is encountered they are joined by [separator].
+  factory TypeAnnotation.fromParts(List<Object> parts,
+          [String separator = '']) =>
+      TypeAnnotation(_combineParts(parts, separator));
 }
 
 final _featureSet = FeatureSet.latestLanguageVersion();
@@ -254,7 +256,7 @@ T _withParserAndToken<T>(
 
 /// Combines [parts] into a [String]. Must only contain [Code] or [String]
 /// instances.
-String _combineParts(List<Object> parts) {
+String _combineParts(List<Object> parts, [String separator = '']) {
   var buffer = StringBuffer();
   for (var part in parts) {
     if (part is String) {
@@ -262,7 +264,7 @@ String _combineParts(List<Object> parts) {
     } else if (part is Code) {
       buffer.write(part.code);
     } else if (part is List<Code>) {
-      buffer.write(part.map((p) => p.code).join(', '));
+      buffer.write(part.map((p) => p.code).join(separator));
     } else {
       throw UnsupportedError(
           'Only String, Code, and List<Code> are allowed but got $part');


### PR DESCRIPTION
Towards https://github.com/jakemac53/macro_prototype/issues/23

cc @goderbauer can you do a review here? Much of this is actually checked in generated code - you can ignore all the `main.*.dart` files except `main.gen.dart` which is the hand written one.

I want to follow up with exploring use cases for listenable objects that come from the build context next.

This also has some extra cleanup in the `fromParts` apis - I realized it doesn't make sense for them to auto-concat nested lists of code with a `,`. Instead you can supply a separator if you wish, otherwise pieces of code are just concatenated directly.

I also did remove the usage of `autoDispose` from the example - right now the prototype implementation doesn't support mixing these two macros together well, I filed a couple of related issues on that.
